### PR TITLE
Fix calendar day selection playback and date indicator

### DIFF
--- a/src/card/actions.js
+++ b/src/card/actions.js
@@ -4,7 +4,7 @@ import { STYLES } from '../styles.js';
 
 // Prototype methods grouped by responsibility.
 export const actionMethods = {
-_goNow() { this._downloadRange=null; this._resetTimelineToNow10m(); this._loadWindow(true); this._renderTimeline(true); this._renderRange(); this._renderTimelineZoomLabel(); this._renderStreamCtrl(); },
+_goNow() { this._downloadRange=null; this._resetTimelineToNow10m(); this._syncCalendarButtonDate?.(Math.floor(Date.now()/1000)); this._loadWindow(true); this._renderTimeline(true); this._renderRange(); this._renderTimelineZoomLabel(); this._renderStreamCtrl(); },
 
 _download(id,file) { const a=document.createElement('a'); a.href=this._media(id,file,true); a.download=`${this._cc().cam}_${id}_${file}`; document.body.appendChild(a); a.click(); a.remove(); },
 
@@ -57,9 +57,38 @@ _toast(msg,ms=3500) {
 
 _toggleFilter() { const p=this.shadowRoot.querySelector('#filter-panel'); const open=p.style.display==='none'; this.shadowRoot.querySelector('#cal-panel').style.display='none'; p.style.display=open?'block':'none'; if(open){ this._mergeLoadedFilterMetadata(this._cc(),this._events,this._reviews); this._loadFrigateFilterMetadata(); this._renderFilter(); } },
 
-_toggleCal() { const p=this.shadowRoot.querySelector('#cal-panel'); const open=p.style.display==='none'; this.shadowRoot.querySelector('#filter-panel').style.display='none'; p.style.display=open?'block':'none'; if(open){ this._calMonth=this._calMonth||new Date(this._winEnd*1000); this._renderCal(); } },
+_toggleCal() { const p=this.shadowRoot.querySelector('#cal-panel'); const open=p.style.display==='none'; this.shadowRoot.querySelector('#filter-panel').style.display='none'; p.style.display=open?'block':'none'; if(open){ this._syncCalendarButtonDate?.(); this._calMonth=this._calMonth||new Date(this._winEnd*1000); this._renderCal(); } },
 
 _calNav(d) { const m=this._calMonth||new Date(); m.setMonth(m.getMonth()+d); this._calMonth=new Date(m); this._renderCal(); },
+
+_syncCalendarButtonDate(ts=this._timelineFocusTs ?? this._winEnd) {
+    const btn=this.shadowRoot?.querySelector('#cal-btn'); if(!btn) return;
+    const seconds=Number(ts);
+    const selected=new Date((Number.isFinite(seconds)?seconds:Date.now()/1000)*1000);
+    const today=new Date();
+    const isToday=selected.getFullYear()===today.getFullYear() && selected.getMonth()===today.getMonth() && selected.getDate()===today.getDate();
+    let label=btn.querySelector('.cal-selected-date');
+    if(!label){
+      label=document.createElement('span');
+      label.className='cal-selected-date';
+      label.style.cssText='margin-left:6px;font-size:10px;font-weight:650;line-height:1;white-space:nowrap;font-variant-numeric:tabular-nums;';
+      btn.appendChild(label);
+    }
+    if(isToday){
+      label.textContent='';
+      label.hidden=true;
+      btn.title='Calendar';
+      btn.setAttribute('aria-label','Calendar');
+      return;
+    }
+    const sameYear=selected.getFullYear()===today.getFullYear();
+    const shortDate=selected.toLocaleDateString([],sameYear?{month:'short',day:'numeric'}:{month:'short',day:'numeric',year:'numeric'});
+    const spokenDate=selected.toLocaleDateString([],{weekday:'long',month:'long',day:'numeric',year:'numeric'});
+    label.textContent=shortDate;
+    label.hidden=false;
+    btn.title=`Calendar · ${spokenDate}`;
+    btn.setAttribute('aria-label',`Calendar, selected ${spokenDate}`);
+  },
 
 _pickDay(ds) {
     const [y,mo,da]=String(ds||'').split('-').map(Number);
@@ -120,12 +149,21 @@ _pickDay(ds) {
     this._exhausted=false;
     this._timelineDataDirty=true;
 
+    const target=this._timelineFocusTs;
     const panel=this.shadowRoot.querySelector('#cal-panel');
     if(panel) panel.style.display='none';
+    this._syncCalendarButtonDate?.(target);
     this._renderTimeline(true);
     this._renderRange();
     this._renderTimelineZoomLabel();
     this._loadWindow(true);
+
+    // Selecting a calendar day is a committed timeline seek. Reuse the same
+    // recording-seek path as a normal tap/scrub so one click both moves the
+    // timeline and starts muted recording playback at the selected timestamp.
+    if(typeof this._seekTimelineTarget==='function') {
+      Promise.resolve(this._seekTimelineTarget(target)).catch(err=>console.warn('[Sightline] calendar seek failed',err));
+    }
   },
 
 _renderCal() {

--- a/tests/timeline-ux.mjs
+++ b/tests/timeline-ux.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const ux=fs.readFileSync(new URL('../src/card/multi-recording.js',import.meta.url),'utf8');
+const actions=fs.readFileSync(new URL('../src/card/actions.js',import.meta.url),'utf8');
 
 assert.ok(ux.includes('_timelineConfiguredPreviewHeight'),'Configured thumbnail height must drive timeline geometry');
 assert.ok(ux.includes('preview.style.top'),'Timeline preview top must be recalculated from its event timestamp');
@@ -11,5 +12,8 @@ assert.ok(ux.includes('_wireDedicatedDownloadRangeDrag'),'Trim picker must have 
 assert.ok(ux.includes('setPointerCapture'),'Trim picker must use pointer capture');
 assert.ok(ux.includes("addEventListener('touchstart'"),'Trim picker must include an iOS touch fallback');
 assert.ok(ux.includes("addEventListener('touchmove'"),'Trim picker touch drag must update continuously');
+assert.ok(actions.includes("this._seekTimelineTarget(target)"),'Calendar day selection must commit through the normal timeline recording seek path');
+assert.ok(actions.includes("cal-selected-date"),'Calendar control must expose the selected non-Today date beside the calendar icon');
+assert.ok(actions.includes("this._syncCalendarButtonDate?.(Math.floor(Date.now()/1000))"),'Returning to Now must clear the historical calendar date label');
 
 console.log('Timeline UX smoke test passed.');


### PR DESCRIPTION
## What changed
- Treat selecting a calendar day as a committed timeline seek, reusing the normal `_seekTimelineTarget()` recording playback path so the user does not need a second tap/click.
- Keep the existing timeline span/zoom and stale-playback invalidation behavior intact.
- Show the selected historical date beside the calendar icon; hide it again when the timeline is on Today/Now.
- Update the calendar button title/ARIA label with the full selected date.
- Add timeline UX regression assertions for calendar autoplay and the selected-date indicator.

## Validation
- `src/card/actions.js` passes `node --check` locally.
- Branch diff is limited to `src/card/actions.js` and `tests/timeline-ux.mjs`.

## Build note
`dist/sightline-for-frigate.js` is generated by `scripts/build.mjs`; this PR changes the source behavior and tests only, so the committed HACS bundle should be regenerated before release/merge if the repository requires dist to stay in sync.