### PR TITLE
Preserve accessors when composing method groups (fixes empty camera picker)

### DIFF
--- a/dist/sightline-for-frigate.js
+++ b/dist/sightline-for-frigate.js
@@ -3476,6 +3476,19 @@ function applyMethodGroups(target, ...groups) {
   }
 }
 
+/**
+ * Merge method groups into a new plain object, preserving accessors.
+ *
+ * Barrels must not use `Object.assign` for this: it copies accessor properties
+ * *by value*, so a group declaring `set hass(h)` (with no getter) collapses into
+ * a dead `hass: undefined` data property and the setter is silently lost.
+ */
+function mergeMethodGroups(...groups) {
+  const merged = {};
+  applyMethodGroups(merged, ...groups);
+  return merged;
+}
+
 // ── src/utils/date.js ──
 /**
  * Small local-date helpers shared by the timeline calendar and editor-facing UI.
@@ -4712,8 +4725,7 @@ _toggleRotate() {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const liveMethods = Object.assign(
-  {},
+const liveMethods = mergeMethodGroups(
   liveDiscoveryMethods,
   liveEngineMethods,
   liveWebRtcMethods,
@@ -5118,8 +5130,7 @@ async _stopTalk() {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const talkMethods = Object.assign(
-  {},
+const talkMethods = mergeMethodGroups(
   talkControlMethods,
   microphoneMethods,
   talkSessionMethods,
@@ -5580,8 +5591,7 @@ _scheduleReload() { clearTimeout(this._rt); this._rt=setTimeout(()=>this._loadWi
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const dataMethods = Object.assign(
-  {},
+const dataMethods = mergeMethodGroups(
   metadataMethods,
   dataLoadingMethods,
 );
@@ -6665,8 +6675,7 @@ _renderMediaFilter(force=false) {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const browserMethods = Object.assign(
-  {},
+const browserMethods = mergeMethodGroups(
   mediaPickerMethods,
   mediaNavigationMethods,
   mediaGalleryMethods,
@@ -7197,8 +7206,7 @@ _recordingCovers(ts) {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const eventPlaybackMethods = Object.assign(
-  {},
+const eventPlaybackMethods = mergeMethodGroups(
   eventPlaybackControllerMethods,
   mediaSourceMethods,
   playbackTimeMethods,
@@ -8050,8 +8058,7 @@ _toggleRecSeek(row) {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const recordingPlaybackMethods = Object.assign(
-  {},
+const recordingPlaybackMethods = mergeMethodGroups(
   recordingTimeMethods,
   recordingShellMethods,
   recordingSourceMethods,
@@ -9517,8 +9524,7 @@ const timelinePlaybackSyncMethods = {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const timelineInteractionMethods = Object.assign(
-  {},
+const timelineInteractionMethods = mergeMethodGroups(
   timelineFilterMethods,
   timelineCalendarMethods,
   timelineGestureMethods,
@@ -10361,8 +10367,7 @@ _reconcileTimeline(track, html) {
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
-const timelineRenderMethods = Object.assign(
-  {},
+const timelineRenderMethods = mergeMethodGroups(
   timelineModelMethods,
   timelineLiveMethods,
   timelineViewMethods,
@@ -11163,8 +11168,7 @@ const multiviewMediaMethods = {
 /**
  * Multiview behavior composed from focused playback, timeline, and media modules.
  */
-const multiviewMethods = Object.assign(
-  {},
+const multiviewMethods = mergeMethodGroups(
   multiviewCoreMethods,
   multiviewPlayerMethods,
   multiviewControllerMethods,
@@ -12227,8 +12231,7 @@ _dispatch() { this.dispatchEvent(new CustomEvent('config-changed',{detail:{confi
 
 // ── src/editor/methods.js ──
 /** Public method-group barrel for the Sightline visual editor. */
-const editorMethods = Object.assign(
-  {},
+const editorMethods = mergeMethodGroups(
   editorRegistryMethods,
   editorRenderMethods,
   editorConfigMethods,

--- a/src/card/browser.js
+++ b/src/card/browser.js
@@ -4,13 +4,13 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { mediaPickerMethods } from './media/picker.js';
 import { mediaNavigationMethods } from './media/navigation.js';
 import { mediaGalleryMethods } from './media/gallery.js';
 import { mediaFilterMethods } from './media/filters.js';
 
-export const browserMethods = Object.assign(
-  {},
+export const browserMethods = mergeMethodGroups(
   mediaPickerMethods,
   mediaNavigationMethods,
   mediaGalleryMethods,

--- a/src/card/data.js
+++ b/src/card/data.js
@@ -4,11 +4,11 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { metadataMethods } from './data/metadata.js';
 import { dataLoadingMethods } from './data/loading.js';
 
-export const dataMethods = Object.assign(
-  {},
+export const dataMethods = mergeMethodGroups(
   metadataMethods,
   dataLoadingMethods,
 );

--- a/src/card/event-playback.js
+++ b/src/card/event-playback.js
@@ -4,12 +4,12 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { eventPlaybackControllerMethods } from './playback/event-controller.js';
 import { mediaSourceMethods } from './playback/media-source.js';
 import { playbackTimeMethods } from './playback/time.js';
 
-export const eventPlaybackMethods = Object.assign(
-  {},
+export const eventPlaybackMethods = mergeMethodGroups(
   eventPlaybackControllerMethods,
   mediaSourceMethods,
   playbackTimeMethods,

--- a/src/card/live.js
+++ b/src/card/live.js
@@ -4,14 +4,14 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { liveDiscoveryMethods } from './live/discovery.js';
 import { liveEngineMethods } from './live/engine.js';
 import { liveWebRtcMethods } from './live/webrtc.js';
 import { liveFullscreenMethods } from './live/fullscreen.js';
 import { liveViewMethods } from './live/view.js';
 
-export const liveMethods = Object.assign(
-  {},
+export const liveMethods = mergeMethodGroups(
   liveDiscoveryMethods,
   liveEngineMethods,
   liveWebRtcMethods,

--- a/src/card/multiview.js
+++ b/src/card/multiview.js
@@ -1,14 +1,14 @@
 /**
  * Multiview behavior composed from focused playback, timeline, and media modules.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { multiviewCoreMethods } from './multiview/core.js';
 import { multiviewPlayerMethods } from './multiview/player.js';
 import { multiviewControllerMethods } from './multiview/controller.js';
 import { multiviewTimelineMethods } from './multiview/timeline-ui.js';
 import { multiviewMediaMethods } from './multiview/media-browser.js';
 
-export const multiviewMethods = Object.assign(
-  {},
+export const multiviewMethods = mergeMethodGroups(
   multiviewCoreMethods,
   multiviewPlayerMethods,
   multiviewControllerMethods,

--- a/src/card/recording-playback.js
+++ b/src/card/recording-playback.js
@@ -4,13 +4,13 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { recordingTimeMethods } from './playback/recording-time.js';
 import { recordingShellMethods } from './playback/recording-shell.js';
 import { recordingSourceMethods } from './playback/recording-source.js';
 import { recordingPlayerMethods } from './playback/recording-player.js';
 
-export const recordingPlaybackMethods = Object.assign(
-  {},
+export const recordingPlaybackMethods = mergeMethodGroups(
   recordingTimeMethods,
   recordingShellMethods,
   recordingSourceMethods,

--- a/src/card/talk.js
+++ b/src/card/talk.js
@@ -4,12 +4,12 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { talkControlMethods } from './talk/controls.js';
 import { microphoneMethods } from './talk/microphone.js';
 import { talkSessionMethods } from './talk/session.js';
 
-export const talkMethods = Object.assign(
-  {},
+export const talkMethods = mergeMethodGroups(
   talkControlMethods,
   microphoneMethods,
   talkSessionMethods,

--- a/src/card/timeline-interaction.js
+++ b/src/card/timeline-interaction.js
@@ -4,6 +4,7 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { timelineFilterMethods } from './timeline/filters.js';
 import { timelineCalendarMethods } from './timeline/calendar.js';
 import { timelineGestureMethods } from './timeline/interaction.js';
@@ -11,8 +12,7 @@ import { timelineRuntimeMethods } from './timeline/runtime.js';
 import { timelineZoomMethods } from './timeline/zoom.js';
 import { timelinePlaybackSyncMethods } from './timeline/playback-sync.js';
 
-export const timelineInteractionMethods = Object.assign(
-  {},
+export const timelineInteractionMethods = mergeMethodGroups(
   timelineFilterMethods,
   timelineCalendarMethods,
   timelineGestureMethods,

--- a/src/card/timeline-render.js
+++ b/src/card/timeline-render.js
@@ -4,12 +4,12 @@
  * Keeping this entry point stable avoids coupling callers to the internal
  * feature layout while allowing each concern to live in a focused module.
  */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { timelineModelMethods } from './timeline/model.js';
 import { timelineLiveMethods } from './timeline/live-follow.js';
 import { timelineViewMethods } from './timeline/render.js';
 
-export const timelineRenderMethods = Object.assign(
-  {},
+export const timelineRenderMethods = mergeMethodGroups(
   timelineModelMethods,
   timelineLiveMethods,
   timelineViewMethods,

--- a/src/editor/methods.js
+++ b/src/editor/methods.js
@@ -1,10 +1,10 @@
 /** Public method-group barrel for the Sightline visual editor. */
+import { mergeMethodGroups } from '../utils/apply-method-groups.js';
 import { editorRegistryMethods } from './registry.js';
 import { editorRenderMethods } from './render.js';
 import { editorConfigMethods } from './config.js';
 
-export const editorMethods = Object.assign(
-  {},
+export const editorMethods = mergeMethodGroups(
   editorRegistryMethods,
   editorRenderMethods,
   editorConfigMethods,

--- a/src/utils/apply-method-groups.js
+++ b/src/utils/apply-method-groups.js
@@ -11,3 +11,16 @@ export function applyMethodGroups(target, ...groups) {
     Object.defineProperties(target, descriptors);
   }
 }
+
+/**
+ * Merge method groups into a new plain object, preserving accessors.
+ *
+ * Barrels must not use `Object.assign` for this: it copies accessor properties
+ * *by value*, so a group declaring `set hass(h)` (with no getter) collapses into
+ * a dead `hass: undefined` data property and the setter is silently lost.
+ */
+export function mergeMethodGroups(...groups) {
+  const merged = {};
+  applyMethodGroups(merged, ...groups);
+  return merged;
+}

--- a/tests/architecture.mjs
+++ b/tests/architecture.mjs
@@ -63,4 +63,35 @@ assert.equal(new Set(BUNDLE_MODULES).size,BUNDLE_MODULES.length,'Build manifest 
   assert.ok(source.includes('this._refreshTimelineInteractionWiring?.(true);'));
 }
 
+// Method-group barrels must preserve accessors. `Object.assign` copies accessor
+// properties *by value*, so a group declaring `set hass(h)` with no getter
+// collapses to a dead `hass: undefined` data property. That silently broke the
+// visual editor: Home Assistant's `editor.hass = hass` never ran the setter, so
+// `_frigateEntities()` fell back to the configured entity list and the camera
+// picker only ever offered the `getStubConfig()` placeholder.
+for(const relative of runtimeFiles) {
+  const source=read(relative);
+  assert.equal(
+    /Methods\s*=\s*Object\.assign\(/.test(source),
+    false,
+    `${relative} must compose method groups with mergeMethodGroups(), not Object.assign (accessors are lost)`,
+  );
+}
+
+{
+  const oldHTMLElement=globalThis.HTMLElement;
+  if(oldHTMLElement===undefined) globalThis.HTMLElement=class {};
+  const [{ SightlineCardEditor },{ SightlineCard }]=await Promise.all([
+    import('../src/editor/SightlineCardEditor.js'),
+    import('../src/card/SightlineCard.js'),
+  ]);
+  for(const [ctor,label] of [[SightlineCardEditor,'SightlineCardEditor'],[SightlineCard,'SightlineCard']]) {
+    const descriptor=Object.getOwnPropertyDescriptor(ctor.prototype,'hass');
+    assert.ok(descriptor,`${label}.prototype must define a hass property`);
+    assert.equal(typeof descriptor.set,'function',`${label}.prototype.hass must remain a setter, not a data property`);
+  }
+  if(oldHTMLElement===undefined) delete globalThis.HTMLElement;
+  else globalThis.HTMLElement=oldHTMLElement;
+}
+
 console.log('Source architecture regression test passed.');


### PR DESCRIPTION
Fixes #11.

## Problem

`src/editor/methods.js` composed the editor's method groups with `Object.assign`, which copies accessor properties **by value** — it runs `[[Get]]` (no getter → `undefined`) and defines a plain data property:

```js
const src = { set hass(h){ this._hass = h; } };
Object.getOwnPropertyDescriptor(Object.assign({}, src), 'hass');
// { value: undefined, writable: true, … }   ← the setter is gone
```

`editorRegistryMethods` declares exactly such an accessor, so `SightlineCardEditor.prototype` ended up with a dead `hass: undefined` data property. Home Assistant's `editor.hass = hass` never ran the setter, `_ensureFrigateEntityRegistry()` was never called, and `_frigateEntities()` permanently took its `if (!this._hass) return this._configuredEntityIds()` branch — so the camera picker only ever offered entities already in the config, i.e. the `getStubConfig()` placeholder `camera.front_door` on a freshly added card.

`applyMethodGroups` was never the problem — it already uses `Object.getOwnPropertyDescriptors` + `Object.defineProperties`. The barrel flattened the accessor before it ever got there.

## Change

- Add `mergeMethodGroups(...groups)` alongside `applyMethodGroups` in `src/utils/apply-method-groups.js` — same descriptor semantics, returns a new object.
- Use it in all ten barrels. **Only `src/editor/methods.js` was actually broken**; the nine card-side barrels contain no accessors today and are converted to remove the latent hazard, so the next `get`/`set` added to a feature module doesn't silently vanish.
- `tests/architecture.mjs`: assert no barrel composes with `Object.assign`, and that `hass` is still a setter on `SightlineCardEditor.prototype` **and** `SightlineCard.prototype`.
- Regenerate `dist/sightline-for-frigate.js` via `npm run build`.

Bundle ordering is fine — the manifest already places `src/utils/apply-method-groups.js` (index 4) before every barrel (earliest is index 13).

## Verification

`npm run verify` passes (build + check + all 9 test files).

Reverting just the `src/editor/methods.js` hunk makes the new test fail with the intended message, and restoring it passes again — so the test is a real regression guard:

```
AssertionError: src/editor/methods.js must compose method groups with
mergeMethodGroups(), not Object.assign (accessors are lost)
```

Driving the editor against a realistic entity registry (4 Frigate cameras + 1 Reolink camera) now yields:

```
_hass received: true
picker options: [ 'camera.camera_bureau', 'camera.camera_chambre_parentale',
                  'camera.camera_mezzanine', 'camera.camera_palier',
                  'camera.front_door' ]
```

The Reolink entity is correctly excluded. `camera.front_door` is retained only because it was the saved config value — that is `_frigateEntities()`'s deliberate "never make an already-saved selection vanish" behaviour, unchanged here.

## Not included

`getStubConfig()` still returns the literal `camera.front_door`, which means every new card starts pointing at an entity that exists on almost no install. Cosmetic once the editor works; noted in #11 and left out to keep this PR to one defect.
